### PR TITLE
Move check_size() out of the class

### DIFF
--- a/hash_table.py
+++ b/hash_table.py
@@ -61,7 +61,7 @@ class HashTable:
     #               and the value is updated.
     def put(self, key, value):
         assert type(key) == str
-        self.check_size() # Note: Don't remove this code.
+        check_size(self.size(), self.bucket_size)  # Note: Don't remove this.
         bucket_index = calculate_hash(key) % self.bucket_size
         item = self.buckets[bucket_index]
         while item:
@@ -81,7 +81,7 @@ class HashTable:
     #               returned. Otherwise, (None, False) is returned.
     def get(self, key):
         assert type(key) == str
-        self.check_size() # Note: Don't remove this code.
+        check_size(self.size(), self.bucket_size)  # Note: Don't remove this.
         bucket_index = calculate_hash(key) % self.bucket_size
         item = self.buckets[bucket_index]
         while item:
@@ -106,15 +106,14 @@ class HashTable:
     def size(self):
         return self.item_count
 
-    # Check that the hash table has a "reasonable" bucket size.
-    # The bucket size is judged "reasonable" if it is smaller than 100 or
-    # the buckets are 30% or more used.
-    #
-    # Note: Don't change this function.
-    def check_size(self):
-        assert (self.bucket_size < 100 or
-                self.item_count >= self.bucket_size * 0.3)
 
+# Check that the hash table has a "reasonable" bucket size.
+# The bucket size is judged "reasonable" if it is smaller than 100 or
+# the buckets are 30% or more used.
+#
+# Note: Don't change this function.
+def check_size(item_count, bucket_size):
+    assert (bucket_size < 100 or item_count >= bucket_size * 0.3)
 
 # Test the functional behavior of the hash table.
 def functional_test():

--- a/hash_table.py
+++ b/hash_table.py
@@ -61,7 +61,7 @@ class HashTable:
     #               and the value is updated.
     def put(self, key, value):
         assert type(key) == str
-        check_size(self.size(), self.bucket_size)  # Note: Don't remove this.
+        check_size(self.size(), self.bucket_size)  # Note: Don't remove this code.
         bucket_index = calculate_hash(key) % self.bucket_size
         item = self.buckets[bucket_index]
         while item:
@@ -81,7 +81,7 @@ class HashTable:
     #               returned. Otherwise, (None, False) is returned.
     def get(self, key):
         assert type(key) == str
-        check_size(self.size(), self.bucket_size)  # Note: Don't remove this.
+        check_size(self.size(), self.bucket_size)  # Note: Don't remove this code.
         bucket_index = calculate_hash(key) % self.bucket_size
         item = self.buckets[bucket_index]
         while item:


### PR DESCRIPTION
The PR moves `check_size()` method out of the class. This will guide STEP Dev Course mentees not to modify the method.

Context: I have observed that the mentees tried to edit the method and call their rehash function inside of the method. I believe that is just because that looks easier and the name implies rehashing for some reasons.

After this change, invoking a rehashing from the method would be impossible without modifying the method signature.