### PR TITLE
Add a test verifying the rehashing does not break anything

### DIFF
--- a/hash_table.py
+++ b/hash_table.py
@@ -179,6 +179,18 @@ def functional_test():
     assert hash_table.delete("acb") == True
     assert hash_table.delete("cab") == True
     assert hash_table.size() == 0
+
+    # Test the rehashing.
+    for i in range(100):
+        hash_table.put(str(i), str(i))
+    for i in range(100):
+        assert hash_table.get(str(i)) == (str(i), True)
+    for i in range(100):
+        assert hash_table.delete(str(i)) == True
+    hash_table.put("abc", 1)
+    hash_table.put("acb", 2)
+    assert hash_table.get("abc") == (1, True)
+    assert hash_table.get("acb") == (2, True)
     print("Functional tests passed!")
 
 


### PR DESCRIPTION
The PR adds a test case that verifies the HashTable works as expected even after a rehashing occurs.

Before this PR, the functional test passes even if a rehashing clears its all data stored in the hash table for example. Or, the test passes even when a rehashing does not happen in a delete operation. This test catches such bugs.

I chose `100` assuming that the mentee does not change the initial hash table size, `97`, and adding `100` items triggers a rehashing. Also, I assume that decreasing the size from `100` to `0` triggers another rehashing. Doing `put` / `get` operation after the deletion is to make sure that the second rehashing occurs; `check_size()` should throw an error otherwise.